### PR TITLE
[不具合修正] サイドバーでプリセット読み込み後、再表示で中身が空になる問題を修正

### DIFF
--- a/web/dialogs/explorer/preset_explorer_sidebar.js
+++ b/web/dialogs/explorer/preset_explorer_sidebar.js
@@ -94,7 +94,7 @@ export class PresetExplorerSidebar extends BasePresetExplorer {
     // ------------------------------------------
     onFileClicked(fileNode) {
         this.callback?.(fileNode);
-        this.updatePathCallback?.(fileNode);
+        this.updatePathCallback?.(fileNode.fullPath);
     }
 
 


### PR DESCRIPTION
サイドバーからプリセットを読み込んだ後、一度サイドバーを閉じてから再度開くと、中身が何も表示されなくなって
しまう現象を修正しました。

onFileClicked で updatePathCallback に fileNode
オブジェクトを渡していたのが原因だったので、fileNode.fullPath を渡すように変更しました。

ご確認よろしくお願いします。